### PR TITLE
Options and protocol env

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+name: Build latest docker image
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    #--- Set permissions to ephemeral GITHUB_TOKEN for job actions
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout and download repository to workflow runner
+        uses: actions/checkout@v3
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to github container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and export to ghcr
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Build and push image to github container registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ avg by (target) (iperf_received_bytes / iperf_received_seconds * 8)
 
 Configuration is via the following environment variables:
 
-| Variable           | Required? | Description                                                              | Default                 |
-| ------------------ | --------- | ------------------------------------------------------------------------ | ----------------------- |
-| `TARGET_LIST`      | yes       | Comma separated list of host names or IP addresses to run tests against. | n/a                     |
-| `TEST_INTERVAL_MS` | no        | How often to run iperf tests.                                            | 600000ms (= 10 minutes) |
+| Variable           | Required? | Description                                                                                                    | Default                 |
+|--------------------|-----------|----------------------------------------------------------------------------------------------------------------|-------------------------|
+| `TARGET_LIST`      | yes       | Comma separated list of host names or IP addresses to run tests against.                                       | n/a                     |
+| `TEST_INTERVAL_MS` | no        | How often to run iperf tests.                                                                                  | 600000ms (= 10 minutes) |
+| `OPTIONS`          | no        | Additional [iperf options](https://github.com/esnet/iperf/blob/master/docs/invoking.rst) (e.g. `--bitrate 1k`) | none                    |
 
 ### `iperf` Server
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Configuration is via the following environment variables:
 | `TARGET_LIST`      | yes       | Comma separated list of host names or IP addresses to run tests against.                                       | n/a                     |
 | `TEST_INTERVAL_MS` | no        | How often to run iperf tests.                                                                                  | 600000ms (= 10 minutes) |
 | `OPTIONS`          | no        | Additional [iperf options](https://github.com/esnet/iperf/blob/master/docs/invoking.rst) (e.g. `--bitrate 1k`) | none                    |
+| `PROTOCOL`         | no        | One of `tcp` or `udp`                                                                                          | `tcp`                   |
 
 ### `iperf` Server
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 
 enum ConfigKey {
   TargetList = "TARGET_LIST",
+  Options = "OPTIONS",
   TestIntervalMs = "TEST_INTERVAL_MS",
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ enum ConfigKey {
   TargetList = "TARGET_LIST",
   Options = "OPTIONS",
   TestIntervalMs = "TEST_INTERVAL_MS",
+  Protocol = "PROTOCOL",
 }
 
 const loadedConfig: Partial<{ [key in ConfigKey]: string }> = {};

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ const exec = util.promisify(execRaw);
 
 // get config
 const targetList = getConfig(ConfigKey.TargetList);
+const options = getConfig(ConfigKey.Options);
 const targets = targetList.split(",").map((t) => t.trim());
 const testIntervalMs = parseInt(getConfig(ConfigKey.TestIntervalMs, "600000"));
 
@@ -17,10 +18,11 @@ async function getMeasurements(): Promise<string[]> {
   for (const target of targets) {
     const tags = {
       target,
+      options,
     };
 
     try {
-      const iperfCmd = await exec(`iperf3 -c ${target} --json`);
+      const iperfCmd = await exec(`iperf3 -c ${target} --json ${options}`);
       const result = JSON.parse(iperfCmd.stdout);
       if (result["error"]) {
         throw result["error"];


### PR DESCRIPTION
Add support for specifying options and protocol (udp/tcp) as new options
Also adds github workflow to publish latest commit in main branch as latest

For udp protocol, only the received metrics are emitted (as sent metrics are missing from json report), and an additional lost_packet metrics is emitted.